### PR TITLE
Buttons default to navigate within site

### DIFF
--- a/frontend/src/components/Button/index.tsx
+++ b/frontend/src/components/Button/index.tsx
@@ -6,11 +6,12 @@ interface IButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   href?: string;
   variant?: "primary" | "secondary";
   size?: "default" | "small";
+  newTab?: boolean;
 }
 
-const ButtonWrapper: React.FC<IButtonProps> = ({ children, href }) => {
+const ButtonWrapper: React.FC<IButtonProps> = ({ children, href, newTab }) => {
   return href ? (
-    <Link to={href} target="_blank">
+    <Link to={href} target={newTab ? "_blank" : "_self"}>
       {children}
     </Link>
   ) : (
@@ -23,13 +24,14 @@ const Button: React.FC<IButtonProps> = ({
   href,
   onClick,
   variant = "primary",
-  size = "default"
+  size = "default",
+  newTab = false,
 }) => {
   const className = `Button--${variant}${size === "small" ? ` ${size}` : ""}`;
 
   return (
-    <ButtonWrapper href={href}>
-      <button className={className} onClick={onClick} >
+    <ButtonWrapper href={href} newTab={newTab}>
+      <button className={className} onClick={onClick}>
         {children}
       </button>
     </ButtonWrapper>

--- a/frontend/src/components/MultiStepForm/index.tsx
+++ b/frontend/src/components/MultiStepForm/index.tsx
@@ -1,6 +1,10 @@
-import { useState, useCallback, ReactElement } from 'react';
+import { useState, useCallback, ReactElement } from "react";
 
-const MultiStepForm = <T,>({ steps, submitFunc, initialData }: IMultiStepFormProps<T>): ReactElement => {
+const MultiStepForm = <T,>({
+  steps,
+  submitFunc,
+  initialData,
+}: IMultiStepFormProps<T>): ReactElement => {
   const [currentStepIndex, setCurrentStepIndex] = useState<number>(0);
   const [formData, setFormData] = useState<T>(initialData);
   const [error, setError] = useState<string | null>(null);
@@ -25,7 +29,8 @@ const MultiStepForm = <T,>({ steps, submitFunc, initialData }: IMultiStepFormPro
 
       // Clear errors on form change
       setError(null);
-    }, []
+    },
+    []
   );
   const handleSubmit = useCallback(async () => {
     const success = await submitFunc(formData);
@@ -47,18 +52,33 @@ const MultiStepForm = <T,>({ steps, submitFunc, initialData }: IMultiStepFormPro
       {error && <div className="form-error">{error}</div>}
 
       <div className="form-navigation">
-        {!isFirstStep && (
-          <button type="button" onClick={handlePrevious} className="btn btn-secondary">
-            Previous
-          </button>
-        )}
+        {
+          // todo: replace these with button component
+          !isFirstStep && (
+            <button
+              type="button"
+              onClick={handlePrevious}
+              className="btn btn-secondary"
+            >
+              Previous
+            </button>
+          )
+        }
         {!isLastStep && (
-          <button type="button" onClick={handleNext} className="btn btn-primary">
+          <button
+            type="button"
+            onClick={handleNext}
+            className="btn btn-primary"
+          >
             Next
           </button>
         )}
         {isLastStep && (
-          <button type="button" onClick={handleSubmit} className="btn btn-success">
+          <button
+            type="button"
+            onClick={handleSubmit}
+            className="btn btn-success"
+          >
             Submit
           </button>
         )}

--- a/frontend/src/pages/Assignments/Assignment/index.tsx
+++ b/frontend/src/pages/Assignments/Assignment/index.tsx
@@ -70,7 +70,10 @@ const Assignment: React.FC = () => {
     <div className="Assignment">
       {assignment && (
         <>
-          <SubPageHeader pageTitle={assignment.name} chevronLink={"/app/dashboard"}>
+          <SubPageHeader
+            pageTitle={assignment.name}
+            chevronLink={"/app/dashboard"}
+          >
             <div className="Assignment__dates">
               <div className="Assignment__date">
                 <div className="Assignment__date--title"> {"Released on:"}</div>
@@ -88,13 +91,13 @@ const Assignment: React.FC = () => {
           </SubPageHeader>
 
           <div className="Assignment__externalButtons">
-            <Button href="" variant="secondary">
+            <Button href="" variant="secondary" newTab>
               View in Github Classroom
             </Button>
-            <Button href="" variant="secondary">
+            <Button href="" variant="secondary" newTab>
               View Starter Code
             </Button>
-            <Button href="" variant="secondary">
+            <Button href="" variant="secondary" newTab>
               View Rubric
             </Button>
           </div>

--- a/frontend/src/pages/Classrooms/Sucess/index.tsx
+++ b/frontend/src/pages/Classrooms/Sucess/index.tsx
@@ -1,22 +1,22 @@
 import Panel from "@/components/Panel";
 import Button from "@/components/Button";
-import { useNavigate } from "react-router-dom";
 import { SelectedClassroomContext } from "@/contexts/selectedClassroom";
 import { useContext } from "react";
 
 import "../styles.css";
 
 const Success: React.FC = () => {
-    const navigate = useNavigate();
-    const { selectedClassroom } = useContext(SelectedClassroomContext);
+  const { selectedClassroom } = useContext(SelectedClassroomContext);
 
-    return (
-        <Panel title={selectedClassroom?.name + " Classroom Created!"} logo={true}>
-            <div className="ButtonWrapper">
-                <Button variant="primary" onClick={() => navigate("/app/dashboard")}>View my classroom</Button>
-            </div>
-        </Panel>
-    );
+  return (
+    <Panel title={selectedClassroom?.name + " Classroom Created!"} logo={true}>
+      <div className="ButtonWrapper">
+        <Button variant="primary" href="/app/dashboard">
+          View my classroom
+        </Button>
+      </div>
+    </Panel>
+  );
 };
 
 export default Success;


### PR DESCRIPTION
# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have reached out to another developer to review my code
- [ ] New and existing unit tests pass locally with my changes
- [ ] All Lint and CI checks are passing


If you want a Button to open a new tab, use prop newTab = {true} or just newTab (which will default to true)