### PR TITLE
Feature/assignment base repo link (KHO-338)

### DIFF
--- a/backend/internal/handlers/classrooms/assignments/assignments.go
+++ b/backend/internal/handlers/classrooms/assignments/assignments.go
@@ -75,6 +75,30 @@ func (s *AssignmentService) getAssignmentTemplate() fiber.Handler {
 	}
 }
 
+// Returns the base repository of an assignment.
+func (s *AssignmentService) getAssignmentBaseRepo() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		assignmentID, err := strconv.ParseInt(c.Params("assignment_id"), 10, 64)
+		if err != nil {
+			return errs.BadRequest(err)
+		}
+
+		assignment, err := s.store.GetAssignmentByID(c.Context(), assignmentID)
+		if err != nil {
+			return errs.InternalServerError()
+		}
+
+		assignmentBaseRepo, err := s.store.GetBaseRepoByID(c.Context(), assignment.BaseRepoID)
+		if err != nil {
+			return errs.InternalServerError()
+		}
+
+		fmt.Println("assignmentBaseRepo", assignmentBaseRepo)
+
+		return c.Status(http.StatusOK).JSON(fiber.Map{"assignment_base_repo": assignmentBaseRepo})
+	}
+}
+
 func (s *AssignmentService) createAssignment() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		// Parse request body

--- a/backend/internal/handlers/classrooms/assignments/assignments.go
+++ b/backend/internal/handlers/classrooms/assignments/assignments.go
@@ -93,8 +93,6 @@ func (s *AssignmentService) getAssignmentBaseRepo() fiber.Handler {
 			return errs.InternalServerError()
 		}
 
-		fmt.Println("assignmentBaseRepo", assignmentBaseRepo)
-
 		return c.Status(http.StatusOK).JSON(fiber.Map{"assignment_base_repo": assignmentBaseRepo})
 	}
 }

--- a/backend/internal/handlers/classrooms/assignments/routes.go
+++ b/backend/internal/handlers/classrooms/assignments/routes.go
@@ -26,6 +26,9 @@ func AssignmentRoutes(router fiber.Router, service *AssignmentService, params *t
 	// Get the template of an assignment
 	assignmentRouter.Get("/assignment/:assignment_id/template", service.getAssignmentTemplate())
 
+	// Get the base repository of an assignment
+	assignmentRouter.Get("/assignment/:assignment_id/baserepo", service.getAssignmentBaseRepo())
+
 	// Create an assignment
 	assignmentRouter.Post("/", service.createAssignment())
 

--- a/frontend/src/api/assignments.ts
+++ b/frontend/src/api/assignments.ts
@@ -123,6 +123,28 @@ export const getAssignmentTemplate = async (
   return data;
 };
 
+export const getAssignmentBaseRepo = async (
+  classroomID: number,
+  assignmentID: number
+): Promise<IAssignmentBaseRepo> => {
+  const result = await fetch(
+    `${base_url}/classrooms/classroom/${classroomID}/assignments/assignment/${assignmentID}/baserepo`,
+    {
+      method: "GET",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  if (!result.ok) {
+    throw new Error("Network response was not ok");
+  }
+
+  const data: IAssignmentBaseRepo = (await result.json()).assignment_base_repo;
+  return data;
+};
+
 export const createAssignment = async (
   templateRepoID: number,
   assignment: IAssignmentFormData

--- a/frontend/src/pages/Assignments/Assignment/index.tsx
+++ b/frontend/src/pages/Assignments/Assignment/index.tsx
@@ -98,7 +98,7 @@ const Assignment: React.FC = () => {
             >
               <MdEditDocument className="icon" /> View Rubric
             </Button>
-            <Button href="#" variant="secondary" newTab>
+            <Button href="#" variant="secondary" disabled={!assignment?.id} newTab>
               <MdEdit className="icon" /> Edit Assignment
             </Button>
           </div>

--- a/frontend/src/pages/Assignments/Assignment/index.tsx
+++ b/frontend/src/pages/Assignments/Assignment/index.tsx
@@ -63,31 +63,22 @@ const Assignment: React.FC = () => {
     }
   }, [linkError, assignmentError, metricsError, assignmentBaseRepoError]);
 
-  if (assignmentIsLoading) {
-    return (
-      <div className="Assignment__loading">
-        <LoadingSpinner />
-      </div>
-    );
-  }
-
   return (
-    assignment && (
       <>
         <SubPageHeader
-          pageTitle={assignment.name}
+          pageTitle={assignment?.name}
           chevronLink={"/app/dashboard"}
         >
           <div className="Assignment__dates">
             <div className="Assignment__date">
               <div className="Assignment__date--title"> {"Released on:"}</div>
-              {assignment.created_at
+              {assignment?.created_at
                 ? formatDate(assignment.created_at)
                 : "N/A"}
             </div>
             <div className="Assignment__date">
               <div className="Assignment__date--title"> {"Due Date:"}</div>
-              {assignment.main_due_date
+              {assignment?.main_due_date
                 ? formatDate(assignment.main_due_date)
                 : "N/A"}
             </div>
@@ -100,8 +91,9 @@ const Assignment: React.FC = () => {
               <FaGithub className="icon" /> View GitHub Repository
             </Button>
             <Button
-              href={`/app/assignments/${assignment.id}/rubric`}
+              href={`/app/assignments/${assignment?.id}/rubric`}
               variant="secondary"
+              disabled={!assignment?.id}
               state={{ assignment }}
             >
               <MdEditDocument className="icon" /> View Rubric
@@ -244,7 +236,7 @@ const Assignment: React.FC = () => {
                       {sa.work_state !== StudentWorkState.NOT_ACCEPTED ? (
                         <Link
                           to={`/app/submissions/${sa.student_work_id}`}
-                          state={{ submission: sa, assignmentId: assignment.id }}
+                          state={{ submission: sa, assignmentId: assignment?.id }}
                           className="Dashboard__assignmentLink">
                           {sa.contributors.map(c => `${c.full_name  }`).join(", ")}
                         </Link>
@@ -285,7 +277,6 @@ const Assignment: React.FC = () => {
           </div>
         </div>
       </>
-    )
   );
 };
 

--- a/frontend/src/pages/Assignments/Assignment/index.tsx
+++ b/frontend/src/pages/Assignments/Assignment/index.tsx
@@ -21,7 +21,6 @@ import { StudentWorkState } from "@/types/enums";
 import { removeUnderscores } from "@/utils/text";
 import { useAssignment, useStudentWorks, useAssignmentInviteLink, useAssignmentBaseRepo, useAssignmentMetrics, useAssignmentTotalCommits } from "@/hooks/useAssignment";
 import { ErrorToast } from "@/components/Toast";
-import LoadingSpinner from "@/components/LoadingSpinner";
 
 ChartJS.register(...registerables);
 ChartJS.register(ChartDataLabels);
@@ -31,8 +30,8 @@ const Assignment: React.FC = () => {
   const { id: assignmentID } = useParams();
   const base_url: string = import.meta.env.VITE_PUBLIC_FRONTEND_DOMAIN as string;
 
-  const { data: assignment, isLoading: assignmentIsLoading, error: assignmentError } = useAssignment(selectedClassroom?.id, Number(assignmentID));
-  const { data: assignmentBaseRepo, isLoading: assignmentBaseRepoIsLoading, error: assignmentBaseRepoError } = useAssignmentBaseRepo(selectedClassroom?.id, Number(assignmentID));
+  const { data: assignment, error: assignmentError } = useAssignment(selectedClassroom?.id, Number(assignmentID));
+  const { data: assignmentBaseRepo, error: assignmentBaseRepoError } = useAssignmentBaseRepo(selectedClassroom?.id, Number(assignmentID));
   const { data: studentWorks } = useStudentWorks(
     selectedClassroom?.id, 
     Number(assignmentID)
@@ -87,7 +86,7 @@ const Assignment: React.FC = () => {
 
         <div className="Assignment">
           <div className="Assignment__externalButtons">
-            <Button href={assignmentBaseRepoLink} variant="secondary" disabled={!assignmentBaseRepoLink || assignmentBaseRepoIsLoading} newTab>
+            <Button href={assignmentBaseRepoLink} variant="secondary" disabled={!assignmentBaseRepoLink} newTab>
               <FaGithub className="icon" /> View GitHub Repository
             </Button>
             <Button

--- a/frontend/src/pages/Assignments/Assignment/index.tsx
+++ b/frontend/src/pages/Assignments/Assignment/index.tsx
@@ -28,7 +28,7 @@ ChartJS.register(ChartDataLabels);
 const Assignment: React.FC = () => {
   const { selectedClassroom } = useContext(SelectedClassroomContext);
   const { id: assignmentID } = useParams();
-  const base_url: string = import.meta.env.VITE_PUBLIC_FRONTEND_DOMAIN as string;
+  const baseUrl: string = import.meta.env.VITE_PUBLIC_FRONTEND_DOMAIN as string;
 
   const { data: assignment, error: assignmentError } = useAssignment(selectedClassroom?.id, Number(assignmentID));
   const { data: assignmentBaseRepo, error: assignmentBaseRepoError } = useAssignmentBaseRepo(selectedClassroom?.id, Number(assignmentID));
@@ -46,7 +46,7 @@ const Assignment: React.FC = () => {
     { label: "Expires: 1 month", value: 43200 },
     { label: "Expires: Never", value: undefined },
   ];
-  const { data: inviteLink = "", isLoading: linkIsLoading, error: linkError } = useAssignmentInviteLink(selectedClassroom?.id, assignment?.id, base_url, expirationDuration.value);
+  const { data: inviteLink = "", isLoading: linkIsLoading, error: linkError } = useAssignmentInviteLink(selectedClassroom?.id, assignment?.id, baseUrl, expirationDuration.value);
 
   const { data: totalAssignmentCommits } = useAssignmentTotalCommits(selectedClassroom?.id, assignment?.id);
   const { acceptanceMetrics, gradedMetrics, error: metricsError } = useAssignmentMetrics(selectedClassroom?.id, Number(assignmentID));

--- a/frontend/src/pages/Assignments/Assignment/styles.css
+++ b/frontend/src/pages/Assignments/Assignment/styles.css
@@ -7,6 +7,13 @@
   gap: 20px;
   padding-bottom: 50px;
 
+  &__loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+  }
+
   &__centerAlignedCell {
     text-align: center;
     display: flex;

--- a/frontend/src/pages/Assignments/Assignment/styles.css
+++ b/frontend/src/pages/Assignments/Assignment/styles.css
@@ -7,13 +7,6 @@
   gap: 20px;
   padding-bottom: 50px;
 
-  &__loading {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100%;
-  }
-
   &__centerAlignedCell {
     text-align: center;
     display: flex;

--- a/frontend/src/pages/Assignments/Assignment/styles.css
+++ b/frontend/src/pages/Assignments/Assignment/styles.css
@@ -2,9 +2,6 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
   padding-bottom: 50px;
 
   &__centerAlignedCell {

--- a/frontend/src/types/assignment.d.ts
+++ b/frontend/src/types/assignment.d.ts
@@ -22,6 +22,14 @@ interface IAssignmentTemplate {
   created_at: Date;
 }
 
+interface IAssignmentBaseRepo {
+  base_repo_owner: string;
+  base_repo_name: string;
+  base_repo_id: number;
+  created_at: Date;
+  initialized: boolean;
+}
+
 interface IAssignmentToken {
   assignment_id: number;
   token: string;


### PR DESCRIPTION
# Summary
- Adds a backend endpoint for getting a base repo
- Changes assignment page's link from linking to the template repository to the base repository (you can still get to the template FROM the base repo)
- Adds reuse of the react query cache for assignments (blazingly fast speeds)
- Note: I accidentally branched off of workflow-rework
- Made a ticket for a UI minor bug KHO-337 (button styling issue)

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have reached out to another developer to review my code
- [ ] New and existing unit tests pass locally with my changes
- [ ] All Lint and CI checks are passing
